### PR TITLE
Improvements to start and stop scripts

### DIFF
--- a/start-tools.bat
+++ b/start-tools.bat
@@ -1,4 +1,10 @@
 @echo off
 
-start java -mx1000m -jar "tools/tika-server-1.16.jar" --port=9998
+:: Installation directory
+SET instDir="%~dp0\"
+
+:: Location of Tika server jar
+SET tikaServerJar=%instDir%\tools\tika-server-1.16.jar
+
+start java -mx1000m -jar %tikaServerJar% --port=9998
 

--- a/start-tools.sh
+++ b/start-tools.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-gnome-terminal -e 'java -mx1000m -jar tools/tika-server-1.16.jar --port=9998'  #> /dev/null 2>&1 &
+# Installation directory
+instDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Location of Tika server jar
+tikaServerJar="$instDir"/tools/tika-server-1.16.jar
+
+gnome-terminal -e "java -mx1000m -jar $tikaServerJar --port=9998"  #> /dev/null 2>&1 &

--- a/stop-tools.bat
+++ b/stop-tools.bat
@@ -1,5 +1,11 @@
 @echo off
 
-stop java -jar "tools/tika-server-1.16.jar"
+:: Installation directory
+SET instDir="%~dp0\"
+
+:: Location of Tika server jar
+SET tikaServerJar=%instDir%\tools\tika-server-1.16.jar
+
+stop java -jar  %tikaServerJar%
 
 exit

--- a/stop-tools.sh
+++ b/stop-tools.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-fuser -l 9998/tcp
+fuser -k 9998/tcp


### PR DESCRIPTION
Hi Ross,

I made some changes that allow you to run the start / stop scripts and batch files independently of the directory from which they are launched. I also fixed an issue with the stop-tools.sh script that ran fuser with the wrong switch.

A remaining issue is that when you run *stop-tools.bat*, it closes the terminal from which it is executed (instead of the child terminal in which Tika is running!). Don't have time to look into this right now but this is probably quite easy to solve.